### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+torch
+torchvision
+numpy
+matplotlib
+tqdm
+pygobject
+pillow


### PR DESCRIPTION
Simple PR to add a requirements.txt file. Was in a fresh python venv so this should be all of the required ones. I noticed this snippet in `site-packages/matplotlib/backends/backend_gtk4.py`:

```python
try:
    import gi
except ImportError as err:
    raise ImportError("The GTK4 backends require PyGObject") from err
```

So while `pygobject` isn't required unless you're running on a GTK4 backend, the error produced when hit if it's missing sometimes doesn't help much without some digging, since it's triggered by the `gi.require_version()` call instead of the try/catch above if you have a different `gi` module installed. So may as well include `pygobject` in the `requirements.txt` file for GTK4 users.

```text
  File "<python venv path>/python3.11/site-packages/matplotlib/backends/backend_gtk4agg.py", line 4, in <module>
    from . import backend_agg, backend_gtk4
  File "<python venv path>/python3.11/site-packages/matplotlib/backends/backend_gtk4.py", line 19, in <module>
    gi.require_version("Gtk", "4.0")
    ^^^^^^^^^^^^^^^^^^
AttributeError: module 'gi' has no attribute 'require_version'
```

(Error comes from `site-packages/matplotlib/backends/backend_gtk4.py` if running a UI based on GTK4 like me).